### PR TITLE
Настроить psalm на поиск неиспользуемого кода

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,6 +33,10 @@ jobs:
         run: composer audit
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
+      - name: Composer require checker
+        run: vendor/bin/composer-require-checker
+      - name: Normalize composer
+        run: composer normalize --dry-run
 
   code-style:
     name: Check code style on PHP ${{ matrix.php }}-${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,13 @@
 {
     "name": "15web/loymax-sdk",
     "description": "PHP SDK for Loymax HTTP API (https://loymax.ru/)",
+    "license": "MIT",
     "type": "library",
-    "keywords": ["loymax", "sdk", "php"],
-    "homepage": "https://github.com/15web/loymax-sdk",
+    "keywords": [
+        "loymax",
+        "sdk",
+        "php"
+    ],
     "authors": [
         {
             "name": "15web",
@@ -11,27 +15,34 @@
             "homepage": "https://www.15web.ru"
         }
     ],
-    "license": "MIT",
+    "homepage": "https://github.com/15web/loymax-sdk",
     "require": {
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.0",
+        "guzzlehttp/psr7": "^2.7",
         "phpdocumentor/reflection-docblock": "^5.4",
         "psr/http-client": "^1.0",
+        "psr/http-message": "^2.0",
         "psr/log": "^3.0",
-        "symfony/property-access": "^6.4|^7.0",
-        "symfony/property-info": "^6.4|^7.0",
-        "symfony/serializer": "^6.4|^7.0",
-        "symfony/uid": "^6.4|^7.0",
+        "symfony/property-access": "^6.4 || ^7.0",
+        "symfony/property-info": "^6.4 || ^7.0",
+        "symfony/serializer": "^6.4 || ^7.0",
+        "symfony/uid": "^6.4 || ^7.0",
         "webmozart/assert": "^1.0"
     },
     "require-dev": {
+        "ergebnis/composer-normalize": "^2.44",
         "friendsofphp/php-cs-fixer": "^3.61",
+        "maglnet/composer-require-checker": "^4.12",
         "phpstan/phpstan": "^1.11",
         "phpstan/phpstan-strict-rules": "^1.6",
         "phpunit/phpunit": "^10.5",
+        "psalm/plugin-phpunit": "^0.19.0",
         "rector/rector": "^1.2",
         "vimeo/psalm": "^5.25"
     },
+    "minimum-stability": "stable",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Studio15\\Loymax\\": "src/"
@@ -42,15 +53,24 @@
             "Studio15\\Loymax\\Test\\": "tests/"
         }
     },
-    "minimum-stability": "stable",
-    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true
+        }
+    },
     "scripts": {
+        "coverage": "php -d pcov.enabled=1 -d pcov.directory=src  vendor/bin/phpunit  --configuration=phpunit.xml  --coverage-text  --coverage-filter=src",
         "phpcsfixer": "vendor/bin/php-cs-fixer --config=php-cs-fixer.php fix --dry-run --diff --ansi -v",
-        "rector": "vendor/bin/rector process --config=rector.config.php --dry-run --ansi",
         "phpstan": "vendor/bin/phpstan analyse -c phpstan-config.neon --ansi",
-        "psalm": "vendor/bin/psalm --config=psalm.xml",
         "phpunit": "vendor/bin/phpunit --configuration=phpunit.xml",
-        "test": ["@phpcsfixer", "@rector", "@phpstan", "@psalm", "@phpunit"],
-        "coverage": "php -d pcov.enabled=1 -d pcov.directory=src  vendor/bin/phpunit  --configuration=phpunit.xml  --coverage-text  --coverage-filter=src"
+        "psalm": "vendor/bin/psalm --config=psalm.xml",
+        "rector": "vendor/bin/rector process --config=rector.config.php --dry-run --ansi",
+        "test": [
+            "@phpcsfixer",
+            "@rector",
+            "@phpstan",
+            "@psalm",
+            "@phpunit"
+        ]
     }
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,22 +5,37 @@
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     findUnusedBaselineEntry="true"
-    findUnusedCode="false"
+    findUnusedCode="true"
+    findUnusedPsalmSuppress="true"
     cacheDirectory="cache/psalm"
 >
     <projectFiles>
-        <directory name="src" />
-        <directory name="tests" />
+        <directory name="src"/>
+        <directory name="tests"/>
     </projectFiles>
 
     <forbiddenFunctions>
         <function name="dd"/>
+        <function name="die"/>
         <function name="dump"/>
-        <function name="var_dump"/>
-        <function name="print_r"/>
+        <function name="echo"/>
+        <function name="empty"/>
+        <function name="eval"/>
+        <function name="exit"/>
+        <function name="print"/>
+        <function name="sleep"/>
+        <function name="usleep"/>
     </forbiddenFunctions>
 
     <issueHandlers>
-        <PluginIssue name="IssueNameEmittedByPlugin" errorLevel="info" />
+        <PossiblyUnusedMethod>
+            <errorLevel type="suppress">
+                <directory name="tests"/>
+            </errorLevel>
+        </PossiblyUnusedMethod>
     </issueHandlers>
+
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
 </psalm>

--- a/src/ApiClient/Exception/BadRequest.php
+++ b/src/ApiClient/Exception/BadRequest.php
@@ -10,6 +10,7 @@ use Studio15\Loymax\ApiClient\Data\HttpStatusCode;
 use Throwable;
 
 /**
+ * @api
  * Некорректный запрос
  */
 final class BadRequest extends ApiClientException

--- a/src/ApiClient/Exception/DeserializeResponseError.php
+++ b/src/ApiClient/Exception/DeserializeResponseError.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\ApiClient\Exception;
 
 /**
+ * @api
  * Ошибка десериализации ответа от API
  */
 final class DeserializeResponseError extends ApiClientException {}

--- a/src/ApiClient/Exception/Forbidden.php
+++ b/src/ApiClient/Exception/Forbidden.php
@@ -7,6 +7,7 @@ namespace Studio15\Loymax\ApiClient\Exception;
 use Studio15\Loymax\ApiClient\Data\HttpStatusCode;
 
 /**
+ * @api
  * Доступ запрещен
  */
 final class Forbidden extends ApiClientException

--- a/src/ApiClient/Exception/InvalidRequest.php
+++ b/src/ApiClient/Exception/InvalidRequest.php
@@ -8,6 +8,7 @@ use Studio15\Loymax\ApiClient\Data\HttpStatusCode;
 use Studio15\Loymax\ApiClient\Response\ValidationError;
 
 /**
+ * @api
  * Запрос содержит ошибки валидации
  */
 final class InvalidRequest extends ApiClientException

--- a/src/ApiClient/Exception/InvalidResponse.php
+++ b/src/ApiClient/Exception/InvalidResponse.php
@@ -9,6 +9,7 @@ use Studio15\Loymax\ApiClient\Data\HttpStatusCode;
 use Studio15\Loymax\ApiClient\Response\Response;
 
 /**
+ * @api
  * Ответ содержит ошибки
  */
 final class InvalidResponse extends ApiClientException

--- a/src/ApiClient/Exception/MethodNotAllowed.php
+++ b/src/ApiClient/Exception/MethodNotAllowed.php
@@ -7,6 +7,7 @@ namespace Studio15\Loymax\ApiClient\Exception;
 use Studio15\Loymax\ApiClient\Data\HttpStatusCode;
 
 /**
+ * @api
  * Неверно указан метод запроса
  */
 final class MethodNotAllowed extends ApiClientException

--- a/src/ApiClient/Exception/NotFound.php
+++ b/src/ApiClient/Exception/NotFound.php
@@ -7,6 +7,7 @@ namespace Studio15\Loymax\ApiClient\Exception;
 use Studio15\Loymax\ApiClient\Data\HttpStatusCode;
 
 /**
+ * @api
  * Метод апи не найден
  */
 final class NotFound extends ApiClientException

--- a/src/ApiClient/Exception/Unauthorized.php
+++ b/src/ApiClient/Exception/Unauthorized.php
@@ -7,6 +7,7 @@ namespace Studio15\Loymax\ApiClient\Exception;
 use Studio15\Loymax\ApiClient\Data\HttpStatusCode;
 
 /**
+ * @api
  * Необходимо авторизоваться
  */
 final class Unauthorized extends ApiClientException

--- a/src/ApiClient/Exception/UnknownErrorException.php
+++ b/src/ApiClient/Exception/UnknownErrorException.php
@@ -7,6 +7,7 @@ namespace Studio15\Loymax\ApiClient\Exception;
 use Throwable;
 
 /**
+ * @api
  * Ошибка приложения
  */
 final class UnknownErrorException extends ApiClientException

--- a/src/ApiClient/Response/Response.php
+++ b/src/ApiClient/Response/Response.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace Studio15\Loymax\ApiClient\Response;
 
 /**
+ * @api
  * Ответ от методов публичного API
- *
- * @internal
  */
 final readonly class Response
 {

--- a/src/ApiClient/Response/Result.php
+++ b/src/ApiClient/Response/Result.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace Studio15\Loymax\ApiClient\Response;
 
 /**
+ * @api
  * Статус обработки запроса к API
- *
- * @internal
  */
 final readonly class Result
 {

--- a/src/ApiClient/Response/ValidationError.php
+++ b/src/ApiClient/Response/ValidationError.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\ApiClient\Response;
 
 /**
+ * @api
  * Ошибка валидации
  */
 final readonly class ValidationError

--- a/src/AuthorizationService.php
+++ b/src/AuthorizationService.php
@@ -16,7 +16,8 @@ use Studio15\Loymax\Authorization\Response\TwoFactorAuthenticationCodeRequired;
 use Studio15\Loymax\Authorization\SendConfirmationCode;
 
 /**
- * Авторизационный сервис
+ * @api
+ * Сервис авторизации
  *
  * @see https://docs.loymax.net/xwiki/bin/view/Main/Integration/Ways_to_use_API/Authorization_Service/
  */

--- a/src/Loymax.php
+++ b/src/Loymax.php
@@ -13,6 +13,7 @@ use Studio15\Loymax\Modules\CommunicationService;
 use Webmozart\Assert\Assert;
 
 /**
+ * @api
  * API Loymax
  */
 final readonly class Loymax

--- a/src/Modules/CommunicationService/Response/Communication.php
+++ b/src/Modules/CommunicationService/Response/Communication.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\Modules\CommunicationService\Response;
 
 /**
+ * @api
  * Персональное предложение
  */
 final readonly class Communication

--- a/src/Modules/CommunicationService/Response/CommunicationList.php
+++ b/src/Modules/CommunicationService/Response/CommunicationList.php
@@ -7,6 +7,7 @@ namespace Studio15\Loymax\Modules\CommunicationService\Response;
 use DateTimeImmutable;
 
 /**
+ * @api
  * Подробная информация о персональных предложениях
  */
 final readonly class CommunicationList

--- a/src/Modules/CommunicationService/Response/CommunicationValue.php
+++ b/src/Modules/CommunicationService/Response/CommunicationValue.php
@@ -7,6 +7,7 @@ namespace Studio15\Loymax\Modules\CommunicationService\Response;
 use DateTimeImmutable;
 
 /**
+ * @api
  * Информация о товаре в персональном предложении
  */
 final readonly class CommunicationValue

--- a/src/Modules/CommunicationService/Response/Image.php
+++ b/src/Modules/CommunicationService/Response/Image.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\Modules\CommunicationService\Response;
 
 /**
+ * @api
  * Изображение
  */
 final readonly class Image

--- a/src/Modules/CommunicationService/Response/Offer.php
+++ b/src/Modules/CommunicationService/Response/Offer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\Modules\CommunicationService\Response;
 
 /**
+ * @api
  * Предложение
  */
 final readonly class Offer

--- a/src/PublicApi/Cards/Response/Balance.php
+++ b/src/PublicApi/Cards/Response/Balance.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\Cards\Response;
 
 /**
+ * @api
  * Информация о балансе карты
  */
 final readonly class Balance

--- a/src/PublicApi/Cards/Response/Card.php
+++ b/src/PublicApi/Cards/Response/Card.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\Cards\Response;
 
 /**
+ * @api
  * Карта
  */
 final readonly class Card

--- a/src/PublicApi/Cards/Response/CardActionAccessInfo.php
+++ b/src/PublicApi/Cards/Response/CardActionAccessInfo.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\Cards\Response;
 
 /**
+ * @api
  * Информация о возможности выполнять действия с картой
  */
 final readonly class CardActionAccessInfo

--- a/src/PublicApi/Cards/Response/CardCategory.php
+++ b/src/PublicApi/Cards/Response/CardCategory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\Cards\Response;
 
 /**
+ * @api
  * Информация о категории карты
  */
 final readonly class CardCategory

--- a/src/PublicApi/Cards/Response/Currency.php
+++ b/src/PublicApi/Cards/Response/Currency.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\Cards\Response;
 
 /**
+ * @api
  * Информации о валюте
  */
 final readonly class Currency

--- a/src/PublicApi/History/Response/AggregatedOperations.php
+++ b/src/PublicApi/History/Response/AggregatedOperations.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\History\Response;
 
 /**
+ * @api
  * Ответ с агрегированными суммами
  */
 final readonly class AggregatedOperations

--- a/src/PublicApi/History/Response/Amount.php
+++ b/src/PublicApi/History/Response/Amount.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\History\Response;
 
 /**
+ * @api
  * Сумма
  */
 final readonly class Amount

--- a/src/PublicApi/History/Response/Brand.php
+++ b/src/PublicApi/History/Response/Brand.php
@@ -7,6 +7,7 @@ namespace Studio15\Loymax\PublicApi\History\Response;
 use Symfony\Component\Uid\Uuid;
 
 /**
+ * @api
  * Бренд
  */
 final readonly class Brand

--- a/src/PublicApi/History/Response/ChequeItem.php
+++ b/src/PublicApi/History/Response/ChequeItem.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\History\Response;
 
 /**
+ * @api
  * Товар в чеке
  */
 final readonly class ChequeItem

--- a/src/PublicApi/History/Response/Currency.php
+++ b/src/PublicApi/History/Response/Currency.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\History\Response;
 
 /**
+ * @api
  * Информации о валюте
  */
 final readonly class Currency

--- a/src/PublicApi/History/Response/Location.php
+++ b/src/PublicApi/History/Response/Location.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\History\Response;
 
 /**
+ * @api
  * Местоположение торговой точки
  */
 final readonly class Location

--- a/src/PublicApi/History/Response/Operation.php
+++ b/src/PublicApi/History/Response/Operation.php
@@ -7,6 +7,7 @@ namespace Studio15\Loymax\PublicApi\History\Response;
 use Symfony\Component\Uid\Uuid;
 
 /**
+ * @api
  * Операция
  */
 final readonly class Operation

--- a/src/PublicApi/History/Response/OperationData.php
+++ b/src/PublicApi/History/Response/OperationData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\History\Response;
 
 /**
+ * @api
  * Данные об операции
  */
 final readonly class OperationData

--- a/src/PublicApi/History/Response/OperationHistory.php
+++ b/src/PublicApi/History/Response/OperationHistory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\History\Response;
 
 /**
+ * @api
  * Ответ с историей операций
  */
 final readonly class OperationHistory

--- a/src/PublicApi/History/Response/Purchase.php
+++ b/src/PublicApi/History/Response/Purchase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\History\Response;
 
 /**
+ * @api
  * Покупка
  */
 final readonly class Purchase

--- a/src/PublicApi/History/Response/Reward.php
+++ b/src/PublicApi/History/Response/Reward.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\History\Response;
 
 /**
+ * @api
  * Начисление
  */
 final readonly class Reward

--- a/src/PublicApi/History/Response/Withdraw.php
+++ b/src/PublicApi/History/Response/Withdraw.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\History\Response;
 
 /**
+ * @api
  * Списание
  */
 final readonly class Withdraw

--- a/src/PublicApi/Merchants/Response/AdditionalInfo.php
+++ b/src/PublicApi/Merchants/Response/AdditionalInfo.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\Merchants\Response;
 
 /**
+ * @api
  * Дополнительная информация о торговой точке
  */
 final readonly class AdditionalInfo

--- a/src/PublicApi/Merchants/Response/City.php
+++ b/src/PublicApi/Merchants/Response/City.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\Merchants\Response;
 
 /**
+ * @api
  * Город
  */
 final readonly class City

--- a/src/PublicApi/Merchants/Response/Location.php
+++ b/src/PublicApi/Merchants/Response/Location.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\Merchants\Response;
 
 /**
+ * @api
  * Местоположение торговой точки
  */
 final readonly class Location

--- a/src/PublicApi/Merchants/Response/Merchant.php
+++ b/src/PublicApi/Merchants/Response/Merchant.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\Merchants\Response;
 
 /**
+ * @api
  * Торговая точка
  */
 final readonly class Merchant

--- a/src/PublicApi/Merchants/Response/Schedule.php
+++ b/src/PublicApi/Merchants/Response/Schedule.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\Merchants\Response;
 
 /**
+ * @api
  * График работы в указанный день
  */
 final readonly class Schedule

--- a/src/PublicApi/Merchants/Response/ScheduleModel.php
+++ b/src/PublicApi/Merchants/Response/ScheduleModel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\Merchants\Response;
 
 /**
+ * @api
  * График работы
  */
 final readonly class ScheduleModel

--- a/src/PublicApi/Notification/Response/Notification.php
+++ b/src/PublicApi/Notification/Response/Notification.php
@@ -7,6 +7,7 @@ namespace Studio15\Loymax\PublicApi\Notification\Response;
 use Symfony\Component\Serializer\Attribute\SerializedName;
 
 /**
+ * @api
  * Оповещение
  */
 final readonly class Notification

--- a/src/PublicApi/Notification/Response/ReadNotificationCount.php
+++ b/src/PublicApi/Notification/Response/ReadNotificationCount.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\Notification\Response;
 
 /**
+ * @api
  * Ответ с количеством прочитанных оповещений
  */
 final readonly class ReadNotificationCount

--- a/src/PublicApi/Notification/Response/UnreadNotificationCount.php
+++ b/src/PublicApi/Notification/Response/UnreadNotificationCount.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\Notification\Response;
 
 /**
+ * @api
  * Ответ с количеством непрочитанных оповещений
  */
 final readonly class UnreadNotificationCount

--- a/src/PublicApi/Offer/Response/Brand.php
+++ b/src/PublicApi/Offer/Response/Brand.php
@@ -7,6 +7,7 @@ namespace Studio15\Loymax\PublicApi\Offer\Response;
 use Symfony\Component\Uid\Uuid;
 
 /**
+ * @api
  * Бренд
  */
 final readonly class Brand

--- a/src/PublicApi/Offer/Response/Image.php
+++ b/src/PublicApi/Offer/Response/Image.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\Offer\Response;
 
 /**
+ * @api
  * Изображение
  */
 final readonly class Image

--- a/src/PublicApi/Offer/Response/Offer.php
+++ b/src/PublicApi/Offer/Response/Offer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\Offer\Response;
 
 /**
+ * @api
  * Акция
  */
 final readonly class Offer

--- a/src/PublicApi/Registration/Response/BeginRegistrationResponse.php
+++ b/src/PublicApi/Registration/Response/BeginRegistrationResponse.php
@@ -7,6 +7,7 @@ namespace Studio15\Loymax\PublicApi\Registration\Response;
 use Studio15\Loymax\Authorization\Response\AccessTokenData;
 
 /**
+ * @api
  * Результат начала регистрации
  */
 final readonly class BeginRegistrationResponse

--- a/src/PublicApi/Registration/Response/TryFinishRegistrationResponse.php
+++ b/src/PublicApi/Registration/Response/TryFinishRegistrationResponse.php
@@ -7,6 +7,7 @@ namespace Studio15\Loymax\PublicApi\Registration\Response;
 use Symfony\Component\Serializer\Attribute\SerializedName;
 
 /**
+ * @api
  * Ответ при попытке завершить регистрацию
  *
  * @see AuthorizationResponse

--- a/src/PublicApi/Registration/Response/UncompletedAction.php
+++ b/src/PublicApi/Registration/Response/UncompletedAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\Registration\Response;
 
 /**
+ * @api
  * Невыполненное действие клиента при регистрации
  */
 final readonly class UncompletedAction

--- a/src/PublicApi/User/Email/Response/EmailChanged.php
+++ b/src/PublicApi/User/Email/Response/EmailChanged.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Email\Response;
 
 /**
+ * @api
  * Результат запроса на смену email
  */
 final readonly class EmailChanged

--- a/src/PublicApi/User/PhoneNumber/Response/PhoneNumber.php
+++ b/src/PublicApi/User/PhoneNumber/Response/PhoneNumber.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\PhoneNumber\Response;
 
 /**
+ * @api
  * Номер телефона
  */
 final readonly class PhoneNumber

--- a/src/PublicApi/User/PhoneNumber/Response/PhoneNumberChanged.php
+++ b/src/PublicApi/User/PhoneNumber/Response/PhoneNumberChanged.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\PhoneNumber\Response;
 
 /**
+ * @api
  * Результат запроса на смену номера телефона
  */
 final readonly class PhoneNumberChanged

--- a/src/PublicApi/User/PhoneNumber/Response/PhoneNumberState.php
+++ b/src/PublicApi/User/PhoneNumber/Response/PhoneNumberState.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\PhoneNumber\Response;
 
 /**
+ * @api
  * Результат запроса на подтверждение номера
  */
 final readonly class PhoneNumberState

--- a/src/PublicApi/User/Request/Answer.php
+++ b/src/PublicApi/User/Request/Answer.php
@@ -7,6 +7,7 @@ namespace Studio15\Loymax\PublicApi\User\Request;
 use Webmozart\Assert\Assert;
 
 /**
+ * @api
  * Ответ на вопрос анкеты
  */
 final readonly class Answer

--- a/src/PublicApi/User/Response/AnswerError.php
+++ b/src/PublicApi/User/Response/AnswerError.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Response;
 
 /**
+ * @api
  * Список ошибок по конкретному ответу на вопрос анкеты
  */
 final readonly class AnswerError

--- a/src/PublicApi/User/Response/AnswerErrors.php
+++ b/src/PublicApi/User/Response/AnswerErrors.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Response;
 
 /**
+ * @api
  * Список всех ошибок по всем ответам на вопросы анкеты
  */
 final readonly class AnswerErrors

--- a/src/PublicApi/User/Response/Attribute.php
+++ b/src/PublicApi/User/Response/Attribute.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use Symfony\Component\Serializer\Attribute\SerializedName;
 
 /**
+ * @api
  * Аттрибут клиента
  */
 final class Attribute

--- a/src/PublicApi/User/Response/Balance.php
+++ b/src/PublicApi/User/Response/Balance.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Response;
 
 /**
+ * @api
  * Информация о балансе клиента
  */
 final readonly class Balance

--- a/src/PublicApi/User/Response/BalanceInfo.php
+++ b/src/PublicApi/User/Response/BalanceInfo.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Response;
 
 /**
+ * @api
  * Баланс клиента
  */
 final readonly class BalanceInfo

--- a/src/PublicApi/User/Response/BalanceShortInfo.php
+++ b/src/PublicApi/User/Response/BalanceShortInfo.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Response;
 
 /**
+ * @api
  * Баланс клиента
  */
 final readonly class BalanceShortInfo

--- a/src/PublicApi/User/Response/Currency.php
+++ b/src/PublicApi/User/Response/Currency.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Response;
 
 /**
+ * @api
  * Информации о валюте
  */
 final readonly class Currency

--- a/src/PublicApi/User/Response/DetailedBalance.php
+++ b/src/PublicApi/User/Response/DetailedBalance.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Response;
 
 /**
+ * @api
  * Детализированный баланс
  */
 final readonly class DetailedBalance

--- a/src/PublicApi/User/Response/Identifier.php
+++ b/src/PublicApi/User/Response/Identifier.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Response;
 
 /**
+ * @api
  * Идентификатор пользователя
  */
 final readonly class Identifier

--- a/src/PublicApi/User/Response/LifeTimesByPeriod.php
+++ b/src/PublicApi/User/Response/LifeTimesByPeriod.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Response;
 
 /**
+ * @api
  * Информация о бонусах, которые активируются/сгорят в указанный период
  */
 final readonly class LifeTimesByPeriod

--- a/src/PublicApi/User/Response/LifeTimesByTime.php
+++ b/src/PublicApi/User/Response/LifeTimesByTime.php
@@ -7,6 +7,7 @@ namespace Studio15\Loymax\PublicApi\User\Response;
 use DateTimeImmutable;
 
 /**
+ * @api
  * Информация о бонусах, которые будут активированы или сгорят в течение недели
  */
 final readonly class LifeTimesByTime

--- a/src/PublicApi/User/Response/Logins.php
+++ b/src/PublicApi/User/Response/Logins.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Response;
 
 /**
+ * @api
  * Список логинов пользователя
  */
 final readonly class Logins

--- a/src/PublicApi/User/Response/RegistrationAction.php
+++ b/src/PublicApi/User/Response/RegistrationAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Response;
 
 /**
+ * @api
  * Шаг регистрации
  */
 final readonly class RegistrationAction

--- a/src/PublicApi/User/Response/RegistrationActionList.php
+++ b/src/PublicApi/User/Response/RegistrationActionList.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Response;
 
 /**
+ * @api
  * Список обязательных шагов регистрации
  */
 final readonly class RegistrationActionList

--- a/src/PublicApi/User/Response/StatusItem.php
+++ b/src/PublicApi/User/Response/StatusItem.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Response;
 
 /**
+ * @api
  * Информация по отдельному статусу статусной системы
  */
 final readonly class StatusItem

--- a/src/PublicApi/User/Response/StatusSystem.php
+++ b/src/PublicApi/User/Response/StatusSystem.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Response;
 
 /**
+ * @api
  * Информация о статусной системе
  */
 final readonly class StatusSystem

--- a/src/PublicApi/User/Response/Subscription.php
+++ b/src/PublicApi/User/Response/Subscription.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Response;
 
 /**
+ * @api
  * Подписка
  */
 final readonly class Subscription

--- a/src/PublicApi/User/Response/SubscriptionChannel.php
+++ b/src/PublicApi/User/Response/SubscriptionChannel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Response;
 
 /**
+ * @api
  * Канал для оповещений
  */
 final readonly class SubscriptionChannel

--- a/src/PublicApi/User/Response/UpdatedSubscription.php
+++ b/src/PublicApi/User/Response/UpdatedSubscription.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Response;
 
 /**
+ * @api
  * Обновленная подписка
  */
 final readonly class UpdatedSubscription

--- a/src/PublicApi/User/Response/UpdatedSubscriptionChannel.php
+++ b/src/PublicApi/User/Response/UpdatedSubscriptionChannel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio15\Loymax\PublicApi\User\Response;
 
 /**
+ * @api
  * Обновленный канал для оповещения
  */
 final readonly class UpdatedSubscriptionChannel

--- a/src/PublicApi/User/Response/User.php
+++ b/src/PublicApi/User/Response/User.php
@@ -7,6 +7,7 @@ namespace Studio15\Loymax\PublicApi\User\Response;
 use DateTimeImmutable;
 
 /**
+ * @api
  * Информация о текущем авторизованном клиенте
  */
 final readonly class User

--- a/src/PublicApiRegistry.php
+++ b/src/PublicApiRegistry.php
@@ -15,6 +15,7 @@ use Studio15\Loymax\PublicApi\Registration;
 use Studio15\Loymax\PublicApi\User;
 
 /**
+ * @api
  * Методы публичного API
  *
  * @see https://docs.loymax.net/xwiki/bin/view/Main/Integration/Ways_to_use_API/API_methods/


### PR DESCRIPTION
Также добавил composer-require-checker для поиска пакетов, которые используются в коде, но явно не прописаны в composer.
Добавил composer-normalize для форматирования и проверки composer.json
